### PR TITLE
Add support for biome tags in sapling overrides

### DIFF
--- a/common/src/main/java/com/outrightwings/data/SaplingOverrides.java
+++ b/common/src/main/java/com/outrightwings/data/SaplingOverrides.java
@@ -1,7 +1,11 @@
 package com.outrightwings.data;
 
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Holder;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.level.biome.Biome;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -22,6 +26,25 @@ public class SaplingOverrides{
             Map<String,FeatureData> biomeFeatureMap = overrides.get(saplingID.toString());
             if(biomeFeatureMap.containsKey(biomeID.toString())){
                 return biomeFeatureMap.get(biomeID.toString()).getFeature(pos,weird,block);
+            }
+        }
+        return null;
+    }
+
+    public String getFeatureIDFromMatchingBiomeTag(ResourceLocation saplingID, Holder<Biome> biomeHolder, BlockPos pos, boolean weird, String block){
+        if(overrides.containsKey(saplingID.toString())){
+            Map<String,FeatureData> biomeFeatureMap = overrides.get(saplingID.toString());
+            for(Map.Entry<String,FeatureData> entry : biomeFeatureMap.entrySet()){
+                String biomeTagID = entry.getKey();
+                if(!biomeTagID.startsWith("#")) continue;
+
+                ResourceLocation biomeTagLocation = ResourceLocation.tryParse(biomeTagID.substring(1));
+                if(biomeTagLocation == null) continue;
+
+                TagKey<Biome> biomeTag = TagKey.create(Registries.BIOME, biomeTagLocation);
+                if(biomeHolder.is(biomeTag)){
+                    return entry.getValue().getFeature(pos,weird,block);
+                }
             }
         }
         return null;

--- a/common/src/main/java/com/outrightwings/data/SingleTreeDataReloadListener.java
+++ b/common/src/main/java/com/outrightwings/data/SingleTreeDataReloadListener.java
@@ -14,7 +14,7 @@ import org.slf4j.Logger;
 import java.io.IOException;
 import java.io.Reader;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class SingleTreeDataReloadListener extends SimplePreparableReloadListener<SaplingOverrides> {
@@ -47,7 +47,7 @@ public class SingleTreeDataReloadListener extends SimplePreparableReloadListener
                     if (json != null) {
                         boolean replace = json.get("replace").getAsBoolean();
 
-                        Map<String,FeatureData> biomeFeatureMap = new HashMap<>();
+                        Map<String,FeatureData> biomeFeatureMap = new LinkedHashMap<>();
                         for(Map.Entry<String, JsonElement> jentry: json.get("values").getAsJsonObject().entrySet()){
                             ArrayList<String> features = new ArrayList<>();
                             ArrayList<String> blocks = new ArrayList<>();

--- a/common/src/main/java/com/outrightwings/growth/TreeOverrideFinder.java
+++ b/common/src/main/java/com/outrightwings/growth/TreeOverrideFinder.java
@@ -13,6 +13,7 @@ import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.util.Tuple;
+import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.chunk.ChunkGenerator;
 import net.minecraft.world.level.levelgen.DensityFunction;
@@ -33,7 +34,8 @@ public class TreeOverrideFinder {
 
     public static Holder<? extends ConfiguredFeature<?, ?>> GetSaplingOverride(ServerLevel level, BlockState state, BlockPos pos, Tuple<Boolean, Point> isMega){
         ResourceLocation sapling = getResourceLocationFromHolder(state.getBlockHolder());
-        ResourceLocation biome = getResourceLocationFromHolder(level.getBiome(pos));
+        Holder<Biome> biomeHolder = level.getBiome(pos);
+        ResourceLocation biome = getResourceLocationFromHolder(biomeHolder);
         BlockPos groundPos = pos.below();
         BlockState groundState = level.getBlockState(groundPos);
         ResourceLocation groundBlock = getResourceLocationFromHolder(groundState.getBlockHolder());
@@ -43,12 +45,17 @@ public class TreeOverrideFinder {
         featureID = GetBlockOverride(isMega,sapling,pos,groundState,weird,groundBlock,level);
         if(featureID == null) featureID = GetSimpleOverride(isMega,sapling,biome,pos,weird,groundBlock.toString());
         if(featureID == null) featureID = GetSimpleOverride(isMega,sapling,allBiomes,pos,weird,groundBlock.toString());
+        if(featureID == null) featureID = GetBiomeTagOverride(isMega,sapling,biomeHolder,pos,weird,groundBlock.toString());
 
         return getConfiguredFeature(level,featureID);
     }
     private static String GetSimpleOverride(Tuple<Boolean, Point> isMega, ResourceLocation sapling, ResourceLocation key, BlockPos pos, Boolean weird, String block){
         return isMega.getA() ? megaSaplingOverrides.getFeatureID(sapling,key, pos, weird, block) :
                 singleSaplingOverrides.getFeatureID(sapling,key, pos, weird, block) ;
+    }
+    private static String GetBiomeTagOverride(Tuple<Boolean, Point> isMega, ResourceLocation sapling, Holder<Biome> biome, BlockPos pos, Boolean weird, String block){
+        return isMega.getA() ? megaSaplingOverrides.getFeatureIDFromMatchingBiomeTag(sapling, biome, pos, weird, block) :
+                singleSaplingOverrides.getFeatureIDFromMatchingBiomeTag(sapling, biome, pos, weird, block) ;
     }
     private static String GetBlockOverride(Tuple<Boolean, Point> isMega, ResourceLocation sapling, BlockPos pos, BlockState groundState, boolean weird, ResourceLocation groundBlock, ServerLevel level){
         if(isMega.getA()){


### PR DESCRIPTION
Hey, nice mod. I'm not sure if you accept PRs, but I wanted this feature so I thought I'd give it a go.

Tested on forge 1.20.1

`sapling_overrides/single/minecraft/acacia_sapling.json`
```json
{
  "replace": false,
  "values": {
    "#minecraft:is_jungle": "minecraft:oak"
  }
}
```