### PR TITLE
Add "treeplacer:none" target to prevent sapling growth

### DIFF
--- a/common/src/main/java/com/outrightwings/growth/TreeOverrideFinder.java
+++ b/common/src/main/java/com/outrightwings/growth/TreeOverrideFinder.java
@@ -27,12 +27,18 @@ import java.util.Optional;
 
 public class TreeOverrideFinder {
     private static final ResourceLocation allBiomes = new ResourceLocation("treeplacer:all_biomes");
+    private static final String noTree = "treeplacer:none";
     private static SaplingOverrides singleSaplingOverrides;
     private static SaplingOverrides megaSaplingOverrides;
     public static void initSingle(SaplingOverrides overrides){singleSaplingOverrides=overrides;}
     public static void initMega(SaplingOverrides overrides){megaSaplingOverrides=overrides;}
 
     public static Holder<? extends ConfiguredFeature<?, ?>> GetSaplingOverride(ServerLevel level, BlockState state, BlockPos pos, Tuple<Boolean, Point> isMega){
+        String featureID = GetSaplingOverrideFeatureID(level,state,pos,isMega);
+        return GetConfiguredFeature(level,featureID);
+    }
+
+    public static String GetSaplingOverrideFeatureID(ServerLevel level, BlockState state, BlockPos pos, Tuple<Boolean, Point> isMega){
         ResourceLocation sapling = getResourceLocationFromHolder(state.getBlockHolder());
         Holder<Biome> biomeHolder = level.getBiome(pos);
         ResourceLocation biome = getResourceLocationFromHolder(biomeHolder);
@@ -47,7 +53,11 @@ public class TreeOverrideFinder {
         if(featureID == null) featureID = GetBiomeTagOverride(isMega,sapling,biomeHolder,pos,weird,groundState);
         if(featureID == null) featureID = GetSimpleOverride(isMega,sapling,allBiomes,pos,weird,groundState);
 
-        return getConfiguredFeature(level,featureID);
+        return featureID;
+    }
+
+    public static boolean IsNoTree(String featureID){
+        return noTree.equals(featureID);
     }
     private static String GetSimpleOverride(Tuple<Boolean, Point> isMega, ResourceLocation sapling, ResourceLocation key, BlockPos pos, Boolean weird, BlockState groundState){
         return isMega.getA() ? megaSaplingOverrides.getFeatureID(sapling,key, pos, weird, groundState) :
@@ -86,7 +96,7 @@ public class TreeOverrideFinder {
         double weirdness = noiserouter.ridges().compute(densityfunction$singlepointcontext);
         return weirdness > 0;
     }
-    private static Holder<ConfiguredFeature<?, ?>> getConfiguredFeature(ServerLevel level, String feature){
+    public static Holder<ConfiguredFeature<?, ?>> GetConfiguredFeature(ServerLevel level, String feature){
         if(feature == null) return null;
         ResourceKey<ConfiguredFeature<?, ?>> key = FeatureUtils.createKey(feature);
         return level.registryAccess().registryOrThrow(Registries.CONFIGURED_FEATURE).getHolder(key).orElse(null);

--- a/common/src/main/java/com/outrightwings/growth/TreePlacer.java
+++ b/common/src/main/java/com/outrightwings/growth/TreePlacer.java
@@ -30,7 +30,9 @@ public class TreePlacer {
     }
     private static int attemptOverride(ServerLevel level, ChunkGenerator chunkGenerator, BlockPos pos, BlockState state, RandomSource random,Tuple<Boolean, Point> isMega){
         Holder<? extends ConfiguredFeature<?, ?>> holder;
-        holder = TreeOverrideFinder.GetSaplingOverride(level,state,pos,isMega);
+        String featureID = TreeOverrideFinder.GetSaplingOverrideFeatureID(level,state,pos,isMega);
+        if(TreeOverrideFinder.IsNoTree(featureID)) return 0;
+        holder = TreeOverrideFinder.GetConfiguredFeature(level,featureID);
         return placeTree(level,chunkGenerator,pos,state,random,holder,isMega);
     }
     private static int placeTree(ServerLevel level, ChunkGenerator chunkGenerator, BlockPos pos, BlockState state, RandomSource random,Holder<? extends ConfiguredFeature<?, ?>> holder,Tuple<Boolean, Point> isMega){


### PR DESCRIPTION
Hello again,

Thanks for merging my previous PR. I'm a big fan of your mod. It is by far my favorite solution for scoping custom saplings.

I found myself missing the ability to block vanilla growth in certain biomes. Using a no_op configured feature can work, but then the sapling disappears which is unintuitive. I think the more minecrafty solution is to block the growth, but keep the placed sapling on the ground, similar to how a sapling without enough vertical space silently fails to grow.

This is my solution. It adds a special target `treeplacer:none` for blocking sapling growth. Is this something the mod can support? Obviously, feel free to edit and change the field name or whatever you want.



Also there's one quirk with this change. If you have mega tree growth target none, then it blocks all growth even if the single is allowed. So for example, any 2x2 configuration of spruce trees will never grow into any tree. I have local changes to work around this with a fallback to the single placement, but it is a lot more code changes so it might be best as another PR. I'll leave it up to you if this behavior is fine or not.

`sapling_overrides/mega/minecraft/spruce_sapling.json`
```json
{
  "replace": false,
  "values": {
    "treeplacer:all_biomes": "treeplacer:none"
  }
}
```
